### PR TITLE
Fix CSV path whens yahoo_finanza is used as a library

### DIFF
--- a/lib/yahoo_finanza/symbol.ex
+++ b/lib/yahoo_finanza/symbol.ex
@@ -74,7 +74,10 @@ defmodule YahooFinanza.Symbol do
   end
 
   defp read_market_symbols(market) do
-    File.stream!("config/markets/#{market}.csv")
+    ~w(.. .. config markets #{market}.csv)
+    |> Path.join
+    |> Path.expand(__DIR__)
+    |> File.stream!
     |> CSV.decode
     |> Enum.flat_map(fn row -> row end)
   end


### PR DESCRIPTION
When including `yahoo_finanza` as a mix dependency, the main "Symbol" process wouldn't start because CSV paths were relative to the host application, and not to the library. This PR fixes the issue.